### PR TITLE
Add NPC conversation on proximity

### DIFF
--- a/my_agent_project/app.py
+++ b/my_agent_project/app.py
@@ -25,12 +25,71 @@ else:
 if not os.getenv("OPENAI_API_KEY"):
     logger.warning("OPENAI_API_KEY is not configured")
 
-# Build initial world with two NPCs
+# Build initial world with player and two NPCs
 WORLD = build_default_world()
+
+
+def _status() -> str:
+    """Return a human-readable status of player and NPCs."""
+    status = {n.name: n.affection for n in WORLD.npcs.values()}
+    status[WORLD.player.name] = WORLD.player.hp
+    return str(status)
+
+
+def start_dialog(npc_name: str, history: List[Tuple[str, str]] | None) -> Tuple[List[Tuple[str, str]], str]:
+    """Move player near ``npc_name`` and begin conversation."""
+    history = history or []
+    npc = WORLD.npcs.get(npc_name.lower())
+    if not npc:
+        logger.warning("NPC %s not found", npc_name)
+        history.append(("系统", f"未找到 NPC {npc_name}"))
+        return history, _status()
+    WORLD.player.move_to(*npc.position)
+    WORLD.active_npc = npc_name.lower()
+    logger.info("Player approaches %s", npc_name)
+    try:
+        reply = get_npc_reply(npc, "你好")
+    except Exception as exc:
+        reply = f"[对话出错]: {exc}"
+        logger.error("Error starting dialog: %s", exc)
+    history.append(("系统", f"你靠近了 {npc.name}"))
+    history.append((npc.name, reply))
+    return history, _status()
+
+
+def end_dialog(history: List[Tuple[str, str]] | None) -> Tuple[List[Tuple[str, str]], str]:
+    """Finish current conversation if any."""
+    history = history or []
+    if WORLD.active_npc:
+        logger.info("End conversation with %s", WORLD.active_npc)
+        history.append(("系统", f"你离开了 {WORLD.active_npc}"))
+        WORLD.active_npc = None
+    else:
+        history.append(("系统", "当前没有进行中的对话"))
+    return history, _status()
+
+
+def on_end(history: List[Tuple[str, str]]) -> Tuple[List[Tuple[str, str]], str]:
+    """Callback for the UI end button."""
+    return end_dialog(history)
 
 
 def process(user_input: str, history: List[Tuple[str, str]]) -> Tuple[List[Tuple[str, str]], str]:
     """Process the player's message and return updated chat history."""
+    if not user_input:
+        logger.debug("Empty user input received")
+        return history or [], _status()
+
+    lowered = user_input.lower()
+    if lowered in ("结束对话", "exit"):
+        return end_dialog(history)
+    if lowered.startswith("approach "):
+        npc_name = user_input.split(" ", 1)[1]
+        return start_dialog(npc_name, history)
+    if lowered.startswith("靠近"):
+        npc_name = user_input[2:].strip()
+        return start_dialog(npc_name, history)
+
     npc, cleaned = route(WORLD, user_input)
     try:
         reply = get_npc_reply(npc, cleaned)
@@ -47,20 +106,26 @@ def process(user_input: str, history: List[Tuple[str, str]]) -> Tuple[List[Tuple
     history = history or []
     history.append(("玩家", user_input))
     history.append((npc.name, reply))
-    status = {n.name: n.affection for n in WORLD.npcs.values()}
-    return history, str(status)
+    return history, _status()
 
 
 def build_interface() -> gr.Blocks:
     with gr.Blocks() as demo:
+        gr.Markdown(f"### Player: {WORLD.player.name}")
+        with gr.Row():
+            gr.Image(value=WORLD.npcs["alice"].avatar, label="Alice")
+            gr.Image(value=WORLD.npcs["bob"].avatar, label="Bob")
+
         chatbot = gr.Chatbot()
         info = gr.Textbox(label="状态信息")
         state = gr.State([])
         with gr.Row():
             msg = gr.Textbox(label="输入")
             btn = gr.Button("发送")
+            end_btn = gr.Button("结束对话")
         btn.click(process, [msg, state], [chatbot, info])
         msg.submit(process, [msg, state], [chatbot, info])
+        end_btn.click(on_end, [state], [chatbot, info])
     return demo
 
 

--- a/my_agent_project/core/factories.py
+++ b/my_agent_project/core/factories.py
@@ -1,21 +1,23 @@
 """Factory helpers for building initial world state."""
 
-from .world_state import WorldState, NPCState
+from .world_state import WorldState, NPCState, PlayerState
 
 
 def build_default_world() -> WorldState:
-    """Create a simple world with two NPCs."""
-    world = WorldState()
+    """Create a default world with one player and two NPCs."""
+    world = WorldState(player=PlayerState(name="Hero", position=(0, 0)))
     world.npcs["alice"] = NPCState(
         name="Alice",
         persona="You are Alice, a cheerful adventurer always eager to help.",
-        avatar="/static/alice.png",
+        avatar="https://via.placeholder.com/150?text=Alice",
         affection=0,
+        position=(1, 0),
     )
     world.npcs["bob"] = NPCState(
         name="Bob",
         persona="You are Bob, a grumpy but kind-hearted guard.",
-        avatar="/static/bob.png",
+        avatar="https://via.placeholder.com/150?text=Bob",
         affection=0,
+        position=(3, 0),
     )
     return world

--- a/my_agent_project/core/router.py
+++ b/my_agent_project/core/router.py
@@ -10,6 +10,15 @@ logger = logging.getLogger(__name__)
 
 def route(world: WorldState, user_input: str) -> Tuple[NPCState, str]:
     """Return the target NPC and cleaned message."""
+    if not world.npcs:
+        raise ValueError("World has no NPCs configured")
+
+    # If player is already in conversation, keep routing to that NPC
+    active = world.get_active_npc()
+    if active is not None:
+        logger.debug("Routing input to active NPC %s", active.name)
+        return active, user_input
+
     lowered = user_input.lower()
     for name, npc in world.npcs.items():
         prefix = f"{name.lower()}:"

--- a/my_agent_project/core/world_state.py
+++ b/my_agent_project/core/world_state.py
@@ -1,7 +1,7 @@
 """Data structures for storing world and NPC state."""
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple, Set
+from typing import Dict, List, Tuple, Set, Optional
 
 from .config import HISTORY_KEEP
 
@@ -13,6 +13,7 @@ class NPCState:
     persona: str
     avatar: str
     affection: int = 0
+    position: Tuple[int, int] = (0, 0)
     history: List[Tuple[str, str]] = field(default_factory=list)
 
     def add_message(self, role: str, content: str, keep: int = HISTORY_KEEP) -> None:
@@ -21,9 +22,39 @@ class NPCState:
         if len(self.history) > keep:
             self.history.pop(0)
 
+
+@dataclass
+class PlayerState:
+    """State associated with the single player."""
+
+    name: str
+    hp: int = 100
+    position: Tuple[int, int] = (0, 0)
+    inventory: List[str] = field(default_factory=list)
+
+    def add_item(self, item: str) -> None:
+        """Add an item to the player's inventory."""
+        self.inventory.append(item)
+
+    def move_to(self, x: int, y: int) -> None:
+        """Move the player to the given coordinates."""
+        self.position = (x, y)
+
+    def distance_to(self, npc: "NPCState") -> int:
+        """Return Manhattan distance to the given NPC."""
+        return abs(self.position[0] - npc.position[0]) + abs(self.position[1] - npc.position[1])
+
 @dataclass
 class WorldState:
     """Global world state tracking NPCs and unlocked events."""
 
+    player: PlayerState = field(default_factory=lambda: PlayerState(name="Hero"))
     npcs: Dict[str, NPCState] = field(default_factory=dict)
     events: Set[str] = field(default_factory=set)
+    active_npc: Optional[str] = None
+
+    def get_active_npc(self) -> Optional[NPCState]:
+        """Return the NPC the player is currently talking to, if any."""
+        if self.active_npc:
+            return self.npcs.get(self.active_npc)
+        return None


### PR DESCRIPTION
## Summary
- add position tracking and active NPC in `WorldState`
- create default world with coordinates for player and NPCs
- route user input to active NPC when in conversation
- introduce helper functions to start/end dialog in `app`
- extend UI with an end button

## Testing
- `python -m py_compile my_agent_project/app.py my_agent_project/core/*.py`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846fa0a80d88330a218ed7331387616