### PR TITLE
Generate avatars locally and refactor async dialog

### DIFF
--- a/my_agent_project/core/avatar.py
+++ b/my_agent_project/core/avatar.py
@@ -1,0 +1,26 @@
+import os
+import logging
+from PIL import Image, ImageDraw
+
+logger = logging.getLogger(__name__)
+
+AVATAR_DIR = os.path.join(os.path.dirname(__file__), '..', 'static')
+
+
+def generate_triangle_avatar(name: str, size: int = 150, color: str = "blue") -> str:
+    """Generate a simple triangular avatar image and return its file path."""
+    os.makedirs(AVATAR_DIR, exist_ok=True)
+    path = os.path.join(AVATAR_DIR, f"{name.lower()}.png")
+    if os.path.exists(path):
+        logger.debug("Avatar for %s already exists: %s", name, path)
+        return path
+    logger.info("Generating avatar for %s", name)
+    img = Image.new("RGBA", (size, size), "white")
+    draw = ImageDraw.Draw(img)
+    draw.polygon([(size / 2, 10), (10, size - 10), (size - 10, size - 10)], fill=color)
+    try:
+        img.save(path)
+    except Exception as exc:
+        logger.error("Failed to save avatar %s: %s", name, exc)
+        raise
+    return path

--- a/my_agent_project/core/dialog.py
+++ b/my_agent_project/core/dialog.py
@@ -48,13 +48,13 @@ def _build_messages(npc: NPCState, user_input: str) -> List[Union[SystemMessage,
     return messages
 
 
-def get_npc_reply(npc: NPCState, user_input: str) -> str:
+async def get_npc_reply(npc: NPCState, user_input: str) -> str:
     """Send conversation to the model and return the assistant reply."""
     client = _ensure_client()
     messages = _build_messages(npc, user_input)
     logger.debug("Sending messages to model: %s", [m.model_dump() for m in messages])
     try:
-        result = asyncio.run(client.create(messages))
+        result = await client.create(messages)
     except Exception as exc:
         logger.error("Failed to get completion: %s", exc)
         raise

--- a/my_agent_project/core/factories.py
+++ b/my_agent_project/core/factories.py
@@ -1,21 +1,24 @@
 """Factory helpers for building initial world state."""
 
-from .world_state import WorldState, NPCState
+from .world_state import WorldState, NPCState, PlayerState
+from .avatar import generate_triangle_avatar
 
 
 def build_default_world() -> WorldState:
-    """Create a simple world with two NPCs."""
-    world = WorldState()
+    """Create a default world with one player and two NPCs."""
+    world = WorldState(player=PlayerState(name="Hero", position=(0, 0)))
     world.npcs["alice"] = NPCState(
         name="Alice",
         persona="You are Alice, a cheerful adventurer always eager to help.",
-        avatar="/static/alice.png",
+        avatar=generate_triangle_avatar("alice"),
         affection=0,
+        position=(1, 0),
     )
     world.npcs["bob"] = NPCState(
         name="Bob",
         persona="You are Bob, a grumpy but kind-hearted guard.",
-        avatar="/static/bob.png",
+        avatar=generate_triangle_avatar("bob", color="green"),
         affection=0,
+        position=(3, 0),
     )
     return world

--- a/my_agent_project/core/router.py
+++ b/my_agent_project/core/router.py
@@ -10,6 +10,15 @@ logger = logging.getLogger(__name__)
 
 def route(world: WorldState, user_input: str) -> Tuple[NPCState, str]:
     """Return the target NPC and cleaned message."""
+    if not world.npcs:
+        raise ValueError("World has no NPCs configured")
+
+    # If player is already in conversation, keep routing to that NPC
+    active = world.get_active_npc()
+    if active is not None:
+        logger.debug("Routing input to active NPC %s", active.name)
+        return active, user_input
+
     lowered = user_input.lower()
     for name, npc in world.npcs.items():
         prefix = f"{name.lower()}:"

--- a/my_agent_project/core/world_state.py
+++ b/my_agent_project/core/world_state.py
@@ -1,7 +1,7 @@
 """Data structures for storing world and NPC state."""
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple, Set
+from typing import Dict, List, Tuple, Set, Optional
 
 from .config import HISTORY_KEEP
 
@@ -13,6 +13,7 @@ class NPCState:
     persona: str
     avatar: str
     affection: int = 0
+    position: Tuple[int, int] = (0, 0)
     history: List[Tuple[str, str]] = field(default_factory=list)
 
     def add_message(self, role: str, content: str, keep: int = HISTORY_KEEP) -> None:
@@ -21,9 +22,39 @@ class NPCState:
         if len(self.history) > keep:
             self.history.pop(0)
 
+
+@dataclass
+class PlayerState:
+    """State associated with the single player."""
+
+    name: str
+    hp: int = 100
+    position: Tuple[int, int] = (0, 0)
+    inventory: List[str] = field(default_factory=list)
+
+    def add_item(self, item: str) -> None:
+        """Add an item to the player's inventory."""
+        self.inventory.append(item)
+
+    def move_to(self, x: int, y: int) -> None:
+        """Move the player to the given coordinates."""
+        self.position = (x, y)
+
+    def distance_to(self, npc: "NPCState") -> int:
+        """Return Manhattan distance to the given NPC."""
+        return abs(self.position[0] - npc.position[0]) + abs(self.position[1] - npc.position[1])
+
 @dataclass
 class WorldState:
     """Global world state tracking NPCs and unlocked events."""
 
+    player: PlayerState = field(default_factory=lambda: PlayerState(name="Hero"))
     npcs: Dict[str, NPCState] = field(default_factory=dict)
     events: Set[str] = field(default_factory=set)
+    active_npc: Optional[str] = None
+
+    def get_active_npc(self) -> Optional[NPCState]:
+        """Return the NPC the player is currently talking to, if any."""
+        if self.active_npc:
+            return self.npcs.get(self.active_npc)
+        return None


### PR DESCRIPTION
## Summary
- generate local triangle avatars for NPCs
- use async `get_npc_reply` to avoid `asyncio.run`
- update world factory and app logic to use generated avatars
- update Gradio callbacks to async

## Testing
- `python -m py_compile my_agent_project/app.py my_agent_project/core/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6846fa0a80d88330a218ed7331387616